### PR TITLE
fix: plugin does not work with postgres

### DIFF
--- a/src/operations/requestOTP.ts
+++ b/src/operations/requestOTP.ts
@@ -43,10 +43,21 @@ export const setOTP = async ({
   const _otpExpiration = new Date(Date.now() + exp * 1000).toISOString()
 
   try {
+    const userData = await payload.db.findOne({
+      collection,
+      joins: false,
+      where: { id: { equals: user.id } },
+    })
+
+    if (!userData) {
+      throw new APIError(`User with ID=${user.id} was not found.`)
+    }
+
     await payload.db.updateOne({
       id: user.id,
       collection,
       data: {
+        ...userData,
         _otp: encrypt({ payload, value: otp }),
         _otpExpiration,
       },


### PR DESCRIPTION
Fixes this plugin with Postgres / SQLite. `payload.db.updateOne` there needs the full data passed because we don't support partial updates at the moment.